### PR TITLE
Fix livestreams (and other videos missing a mimetype)

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -3,7 +3,7 @@
   "author": "Andreas Smas",
   "title": "Youtube",
   "synopsis": "Youtube: Broadcast Yourself",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "file": "youtube.js",
   "showtimeVersion": "5.0.211",
   "type": "ecmascript",

--- a/youtube.js
+++ b/youtube.js
@@ -268,7 +268,7 @@ function videoPage(page, id) {
       canonicalUrl: PREFIX + ':video:' + info.video_id,
       sources: [{
         url: info.formats[0].url,
-        mimetype: info.formats[0].type.split(';')[0],
+        mimetype: (info.formats[0].type || '').split(';')[0],
       }],
       no_subtitle_scan: true,
       subtitles: []


### PR DESCRIPTION
Add a fallback when format type isn't given.
Fixes bug [#3225](https://movian.tv/issues/3225).