### PR TITLE
Fix for youtube play failure

### DIFF
--- a/youtube.js
+++ b/youtube.js
@@ -131,9 +131,9 @@ new page.Route(PREFIX + ":categories", function(page) {
 });
 
 new page.Route(PREFIX + ":my:subscriptions", function(page) {
-  page.metadata.title = "Recent activity";
-  require('./browse').browse('activities', page, {
-    home: true,
+  page.metadata.title = "Recent subscriptions";
+  require('./browse').browse('subscriptions', page, {
+    mine: true,
     part: 'snippet,contentDetails',
   });
 });

--- a/ytdl-core/lib/sig.js
+++ b/ytdl-core/lib/sig.js
@@ -190,7 +190,7 @@ var spliceStr = ':function\\(a,b\\)\\{' +
   'a\\.splice\\(0,b\\)' +
 '\\}';
 var swapStr = ':function\\(a,b\\)\\{' +
-  'var c=a\\[0\\];a\\[0\\]=a\\[b%a\\.length\\];a\\[b\\]=c(?:;return a)?' +
+  'var c=a\\[0\\];a\\[0\\]=a\\[b(?:%a\\.length)?\\];a\\[b(?:%a\\.length)?\\]=c(?:;return a)?' +
 '\\}';
 var actionsObjRegexp = new RegExp(
   'var (' + jsvarStr + ')=\\{((?:(?:' +


### PR DESCRIPTION
Hello.
Here is small fix regarding youtube failure:
Sig.js line 193:
'var c=a\\[0\\];a\\[0\\]=a\\[b(?:%a\\.length)?\\];a\\[b(?:%a\\.length)?\\]=c(?:;return a)?' + 

And one more change includes subscriptions not working as expected from my perspective:
youtube.js (lines 134-137):
  page.metadata.title = "Recent subscriptions";
  require('./browse').browse('subscriptions', page, {
    mine: true,
    part: 'snippet,contentDetails',
  });
