### PR TITLE
Landing Page with activities/subscriptions

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -3,7 +3,7 @@
   "author": "Andreas Smas",
   "title": "Youtube",
   "synopsis": "Youtube: Broadcast Yourself",
-  "version": "5.0.14",
+  "version": "5.0.15",
   "file": "youtube.js",
   "showtimeVersion": "5.0.462",
   "type": "ecmascript",

--- a/youtube.js
+++ b/youtube.js
@@ -130,10 +130,18 @@ new page.Route(PREFIX + ":categories", function(page) {
   });
 });
 
-new page.Route(PREFIX + ":my:subscriptions", function(page) {
+new page.Route(PREFIX + ":my:activities", function(page) {
   page.metadata.title = "Recent activity";
   require('./browse').browse('activities', page, {
     home: true,
+    part: 'snippet,contentDetails',
+  });
+});
+
+new page.Route(PREFIX + ":my:subscriptions", function(page) {
+  page.metadata.title = "My subscriptions";
+  require('./browse').browse('subscriptions', page, {
+    mine: true,
     part: 'snippet,contentDetails',
   });
 });
@@ -229,9 +237,13 @@ new page.Route(PREFIX + ":start", function(page) {
     title: 'My Youtube'
   });
 
+  page.appendItem(PREFIX + ":my:activities", 'directory', {
+    title: "YouTube home page activities",
+  }).root.subtype = 'subscriptions';
+
   page.appendItem(PREFIX + ":my:subscriptions", 'directory', {
     title: "My subscriptions",
-  }).root.subtype = 'subscriptions';
+  });
 
 
   page.appendItem(PREFIX + ":my:channel", 'directory', {


### PR DESCRIPTION
i think this will be better for landing page
in 5.0.14 you revert activities/subscriptions 
if you look at https://developers.google.com/youtube/v3/docs/activities/list 
we get Activity feed from YouTube home page not subscriptions
with https://developers.google.com/youtube/v3/docs/subscriptions
we get actually subscriptions